### PR TITLE
Fix buffer overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build
-.vscode
+#.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "cerr",
         "Doxywizard",
+        "fsanitize",
         "fstack",
         "gmock",
         "googletest",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Added a new function `LinAlg::scaleSqMat`.
-- Added compiler options for secure programming
-  - `-Wextra`, `-Wold-style-cast`, `-Wredundant-decls`, `-Wshadow`, `-Wswitch-default`, `-Wswitch-enum` (debug/release build)
-  - `-fstack-protector`, `-ftrapv` (debug build)
-
-## [0.5.0] - 2021/9/13
-
 - Added `MATH_LIB_INLINE_AGGRESSIVELY` option.
 - Speeded up following functions:
   - `Analysis::`
@@ -23,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SigProc::`
     - `convolve`, `convolve_type2`
 - Improved include-guard: replaced old-style guard using `#ifndef` with `#pragma once`.
-- Added `LinAlg::fillLowTri`, `LinAlg::addSqMat` function.
+- Added `LinAlg::fillLowTri`, `LinAlg::addSqMat`, `LinAlg::scaleSqMat` function.
 - Refactored polynomial approximation of arc tangent:
   - Added `atan_polyApprox_deg7` function.
   - Renamed `atan_polyApprox` to `atan_polyApprox_deg9`.
@@ -35,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forcibly inline-expand the following small functions:
   - `LinAlg::`
     - `isEqualVec`, `complexVec`, `conjugateVec`, `addVec`, `scaleVec`, `l2Norm`
+- Added compiler options for secure programming
+  - `-Wextra`, `-Wold-style-cast`, `-Wredundant-decls`, `-Wshadow`, `-Wswitch-default`, `-Wswitch-enum` (debug/release build)
+  - `-fstack-protector`, `-ftrapv` (debug build)
 
 ## [0.4.0] - 2021/8/27
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wfatal-errors -Winline -Wold-style-cast -Wredundant-decls -Wshadow -Wswitch-default -Wswitch-enum -Wundef")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -fstack-protector -ftrapv")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -fstack-protector -fsanitize=address -ftrapv")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 # Set the project name and language.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wfatal-errors -Winline -Wold-style-cast -Wredundant-decls -Wshadow -Wswitch-default -Wswitch-enum -Wundef")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -fstack-protector -fsanitize=address -ftrapv")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -fsanitize=address -fstack-protector -ftrapv")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 # Set the project name and language.

--- a/include/RlsFilter.hpp
+++ b/include/RlsFilter.hpp
@@ -160,7 +160,7 @@ namespace MathLib {
 
                 for (int n=0; n<Ld; ++n) {
                     using namespace MathLib::LinAlg;
-                    std::reverse_copy(&vec_x[n*r_T - (Ld-1)], &vec_x[n*r_T+1], m_x);
+                    std::reverse_copy(&vec_x[n*r_T - m_p], &vec_x[n*r_T+1], m_x);
                     conjugateVec(m_p+1, m_x, m_x_conj);
                     mulMat(m_p+1, 1, m_p+1, m_x_conj, m_x, m_delta_R_x);
                     addMat(m_p+1, m_p+1, m_R_x, m_delta_R_x);

--- a/include/RlsFilter.hpp
+++ b/include/RlsFilter.hpp
@@ -136,7 +136,7 @@ namespace MathLib {
              * @attention vec_x[-p], ..., vec_x[-1] must be valid data.
              * @attention When `Ld < 1`, this function does nothing and returns immediately in release build, aborts in debug build.
              */
-            void trainHard(const T *vec_d, const T *vec_x, int Ld, T *w_opt) {
+            void trainHard(const T *const vec_d, const T *const vec_x, const int Ld, T *const w_opt) {
                 #define IS_DEBUGGING false
                 assert(Ld >= 1);
                 if (Ld < 1) {

--- a/include/linAlg.hpp
+++ b/include/linAlg.hpp
@@ -212,7 +212,8 @@ namespace MathLib {
         #endif
         fillLowTri(const int m, T *const A, const T x, const int d=0) {
             for (int r=0; r<m; ++r) {
-                const int c_end = r+d;
+                const int c_end_temp = r+d;
+                const int c_end = (c_end_temp < m ? c_end_temp : m-1);
                 T *const A_row_ptr = &A[r*m];
                 for (int c=0; c<=c_end; ++c) {A_row_ptr[c] = x;}
             }

--- a/include/linAlg.hpp
+++ b/include/linAlg.hpp
@@ -190,9 +190,9 @@ namespace MathLib {
          */
         template <typename T>
         #if MATH_LIB_INLINE_AGGRESSIVELY
-        inline static void __attribute__((always_inline))
+            inline static void __attribute__((always_inline))
         #else
-        void
+            void
         #endif
         setDiag(const size_t m, const T *const d, T *const A) {
             for (size_t r=0; r<m; ++r) {A[r*m+r] = d[r];}
@@ -206,9 +206,9 @@ namespace MathLib {
          */
         template <typename T>
         #if MATH_LIB_INLINE_AGGRESSIVELY
-        inline static void __attribute__((always_inline))
+            inline static void __attribute__((always_inline))
         #else
-        void
+            void
         #endif
         fillLowTri(const int m, T *const A, const T x, const int d=0) {
             for (int r=0; r<m; ++r) {

--- a/test/test_RlsFilter.cpp
+++ b/test/test_RlsFilter.cpp
@@ -20,14 +20,15 @@ namespace {
     class RlsFilterTest : public ::testing::Test{};
 
     TEST_F(RlsFilterTest, case1_thinningRate_1) {
-        const std::array<std::complex<double>, 10> vec_x = {{
+        constexpr int m = 10;
+        const std::array<std::complex<double>, m> vec_x = {{
             {0.06412935, 0.88332087}, {0.99244617, 0.12382741}, {0.64271018, 0.45058685},
             {0.99968758, 0.67847759}, {0.94431826, 0.48793753}, {0.4698219 , 0.01647779},
             {0.93984455, 0.37076489}, {0.01225688, 0.67889914}, {0.43928084, 0.22816118},
             {0.66261685, 0.13262789}
         }};
 
-        const std::array<std::complex<double>, 10> vec_y = {{
+        const std::array<std::complex<double>, m> vec_y = {{
             {0.06412935, 0.88332087}, {1.00847851, 0.34465762}, {0.89883789, 0.59195881},
             {1.2844209 , 0.80660273}, {1.27457893, 0.71388028}, {0.83086241, 0.22327187},
             {1.17533981, 0.43587653}, {0.30594575, 0.77365009}, {0.55982563, 0.44423158},
@@ -39,11 +40,12 @@ namespace {
         MathLib::RlsFilter<std::complex<double>> rlsFilter(p, thinningRate);
 
         std::array<std::complex<double>, p+1> w_opt;
-        rlsFilter.trainHard(vec_x.data(), vec_y.data(), vec_x.size(), w_opt.data());
+        rlsFilter.trainHard(vec_x.data()+p, vec_y.data()+p, m-p, w_opt.data());
 
         const std::array<std::complex<double>, p+1> w_opt_ans = {{
-            {1.0036556, -0.0025984}, {-0.2384301, 0.0000261}, {-0.0427164, 0.0031466}
+            {1.00805183, 0.00350714}, {-0.23721696, -0.00627859}, {-0.04749628, 0.00389941}
         }};
+        //MathLib::LinAlg::Debug::printComplexVec(p+1, w_opt.data(), "%10.8f + i(%10.8f)");
         EXPECT_EQ(true, MathLib::LinAlg::isEqualVec(w_opt.size(), w_opt.data(), w_opt_ans.data(), 1.0e-7l));
     }
 }

--- a/test/test_sigProc.cpp
+++ b/test/test_sigProc.cpp
@@ -22,7 +22,7 @@ namespace {
         const std::complex<double> x2[5] = {-1.36, 3.74, -3.97, 4.64, -3.88};
         std::complex<double> y[10+5-1];
         const std::complex<double> y_ans[10+5-1] = {-5.4808, 21.1106, -26.2807, 24.0622, -26.6141, 1.0675, 8.4943, -6.4678, 22.6594, -18.183, 23.68, -7.5533, 1.2216, 10.2044};
-        MathLib::SigProc::convolve(5, 10, &x1[0], &x2[0], &y[0]);
+        MathLib::SigProc::convolve(10, 5, &x1[0], &x2[0], &y[0]);
         EXPECT_EQ(true, MathLib::LinAlg::isEqualVec(3, &y[0], &y_ans[0], 1.0e-7l));
     }
 


### PR DESCRIPTION
- Added compiler options for secure programming
  - `-Wextra`, `-Wold-style-cast`, `-Wredundant-decls`, `-Wshadow`, `-Wswitch-default`, `-Wswitch-enum` (debug/release build)
  - `-fstack-protector`, `-ftrapv` (debug build)
- Fixed buffer overflow bugs in the following functions:
  - `LinAlg::fillLowTri`
  - `RlsFilter::trainHard`
- Fixed a buffer overflow bug in a test case `TEST_F(RlsFilterTest, case1_thinningRate_1)`.